### PR TITLE
Adds setup fee support on subscriptions to the .NET library

### DIFF
--- a/GoCardlessSdk.Tests/Connect/ConnectTests.cs
+++ b/GoCardlessSdk.Tests/Connect/ConnectTests.cs
@@ -148,7 +148,7 @@ namespace GoCardlessSdk.Tests.Connect
                                   Name = "Premium Account",
                                   Description = "test subscription",
                                   IntervalCount = 12,
-                                  SetupFee = 10.00,
+                                  SetupFee = 10,
                                   User = new UserRequest
                                              {
                                                  Name = "John Smith",

--- a/GoCardlessSdk.Tests/Connect/ConnectTests.cs
+++ b/GoCardlessSdk.Tests/Connect/ConnectTests.cs
@@ -166,12 +166,12 @@ namespace GoCardlessSdk.Tests.Connect
             GoCardless.AccountDetails.AppId = "test_id";
             GoCardless.AccountDetails.AppSecret = "test_secret";
             GoCardless.GenerateNonce = () => "Q9gMPVBZixfRiQ9VnRdDyrrMiskqT0ox8IT+HO3ReWMxavlco0Fw8rva+ZcI";
-            GoCardless.GetUtcNow = () => new DateTimeOffset(new DateTime(2012, 03, 21, 08, 55, 56));
+            GoCardless.GetUtcNow = () => new DateTimeOffset(new DateTime(2012, 03, 21, 13, 08, 56));
 
             var url = GoCardless.Connect.NewSubscriptionUrl(request);
-            var expected =
-                "https://sandbox.gocardless.com/connect/subscriptions/new?client_id=test_id&nonce=Q9gMPVBZixfRiQ9VnRdDyrrMiskqT0ox8IT%2BHO3ReWMxavlco0Fw8rva%2BZcI&signature=7b5a1fe9abc37a21c9cd8b22cd09dfbca9ec3d8d9cd1083796c6a4cbef666984&subscription%5Bamount%5D=15.00&subscription%5Bdescription%5D=test%20subscription&subscription%5Bexpires_at%5D=2013-03-24T19%3A32%3A22Z&subscription%5Binterval_count%5D=12&subscription%5Binterval_length%5D=1&subscription%5Binterval_unit%5D=month&subscription%5Bmerchant_id%5D=0190G74E3J&subscription%5Bname%5D=Premium%20Account&subscription%5Bsetup_fee%5D=10.00&subscription%5Bstart_at%5D=2012-03-24T19%3A32%3A22Z&subscription%5Buser%5D%5Bbilling_address1%5D=Flat%201&subscription%5Buser%5D%5Bbilling_address2%5D=100%20Main%20Street&subscription%5Buser%5D%5Bbilling_county%5D=Countyshire&subscription%5Buser%5D%5Bbilling_postcode%5D=N1%201AB&subscription%5Buser%5D%5Bbilling_town%5D=Townville&subscription%5Buser%5D%5Bemail%5D=john.smith%40example.com&subscription%5Buser%5D%5Bfirst_name%5D=John&subscription%5Buser%5D%5Blast_name%5D=Smith&subscription%5Buser%5D%5Bname%5D=John%20Smith&timestamp=2012-03-21T08%3A55%3A56Z";
-            Assert.AreEqual(expected, url);
+			Console.WriteLine(url);
+			var expected = "https://sandbox.gocardless.com/connect/subscriptions/new?client_id=test_id&nonce=Q9gMPVBZixfRiQ9VnRdDyrrMiskqT0ox8IT%2BHO3ReWMxavlco0Fw8rva%2BZcI&signature=26cc02eeb1e24d98ed584a89d224b2f904c2611e1d976a635b0fb4dfc092713b&subscription%5Bamount%5D=15.00&subscription%5Bdescription%5D=test%20subscription&subscription%5Bexpires_at%5D=2013-03-24T19%3A32%3A22Z&subscription%5Binterval_count%5D=12&subscription%5Binterval_length%5D=1&subscription%5Binterval_unit%5D=month&subscription%5Bmerchant_id%5D=0190G74E3J&subscription%5Bname%5D=Premium%20Account&subscription%5Bsetup_fee%5D=10.00&subscription%5Bstart_at%5D=2012-03-24T19%3A32%3A22Z&subscription%5Buser%5D%5Bbilling_address1%5D=Flat%201&subscription%5Buser%5D%5Bbilling_address2%5D=100%20Main%20Street&subscription%5Buser%5D%5Bbilling_county%5D=Countyshire&subscription%5Buser%5D%5Bbilling_postcode%5D=N1%201AB&subscription%5Buser%5D%5Bbilling_town%5D=Townville&subscription%5Buser%5D%5Bemail%5D=john.smith%40example.com&subscription%5Buser%5D%5Bfirst_name%5D=John&subscription%5Buser%5D%5Blast_name%5D=Smith&subscription%5Buser%5D%5Bname%5D=John%20Smith&timestamp=2012-03-21T13%3A08%3A56Z";
+		    Assert.AreEqual(expected, url);
         }
     }
 }

--- a/GoCardlessSdk.Tests/Connect/ConnectTests.cs
+++ b/GoCardlessSdk.Tests/Connect/ConnectTests.cs
@@ -148,6 +148,7 @@ namespace GoCardlessSdk.Tests.Connect
                                   Name = "Premium Account",
                                   Description = "test subscription",
                                   IntervalCount = 12,
+                                  SetupFee = 10.00,
                                   User = new UserRequest
                                              {
                                                  Name = "John Smith",
@@ -169,7 +170,7 @@ namespace GoCardlessSdk.Tests.Connect
 
             var url = GoCardless.Connect.NewSubscriptionUrl(request);
             var expected =
-                "https://sandbox.gocardless.com/connect/subscriptions/new?client_id=test_id&nonce=Q9gMPVBZixfRiQ9VnRdDyrrMiskqT0ox8IT%2BHO3ReWMxavlco0Fw8rva%2BZcI&signature=7b5a1fe9abc37a21c9cd8b22cd09dfbca9ec3d8d9cd1083796c6a4cbef666984&subscription%5Bamount%5D=15.00&subscription%5Bdescription%5D=test%20subscription&subscription%5Bexpires_at%5D=2013-03-24T19%3A32%3A22Z&subscription%5Binterval_count%5D=12&subscription%5Binterval_length%5D=1&subscription%5Binterval_unit%5D=month&subscription%5Bmerchant_id%5D=0190G74E3J&subscription%5Bname%5D=Premium%20Account&subscription%5Bstart_at%5D=2012-03-24T19%3A32%3A22Z&subscription%5Buser%5D%5Bbilling_address1%5D=Flat%201&subscription%5Buser%5D%5Bbilling_address2%5D=100%20Main%20Street&subscription%5Buser%5D%5Bbilling_county%5D=Countyshire&subscription%5Buser%5D%5Bbilling_postcode%5D=N1%201AB&subscription%5Buser%5D%5Bbilling_town%5D=Townville&subscription%5Buser%5D%5Bemail%5D=john.smith%40example.com&subscription%5Buser%5D%5Bfirst_name%5D=John&subscription%5Buser%5D%5Blast_name%5D=Smith&subscription%5Buser%5D%5Bname%5D=John%20Smith&timestamp=2012-03-21T08%3A55%3A56Z";
+                "https://sandbox.gocardless.com/connect/subscriptions/new?client_id=test_id&nonce=Q9gMPVBZixfRiQ9VnRdDyrrMiskqT0ox8IT%2BHO3ReWMxavlco0Fw8rva%2BZcI&signature=7b5a1fe9abc37a21c9cd8b22cd09dfbca9ec3d8d9cd1083796c6a4cbef666984&subscription%5Bamount%5D=15.00&subscription%5Bdescription%5D=test%20subscription&subscription%5Bexpires_at%5D=2013-03-24T19%3A32%3A22Z&subscription%5Binterval_count%5D=12&subscription%5Binterval_length%5D=1&subscription%5Binterval_unit%5D=month&subscription%5Bmerchant_id%5D=0190G74E3J&subscription%5Bname%5D=Premium%20Account&subscription%5Bsetup_fee%5D=10.00&subscription%5Bstart_at%5D=2012-03-24T19%3A32%3A22Z&subscription%5Buser%5D%5Bbilling_address1%5D=Flat%201&subscription%5Buser%5D%5Bbilling_address2%5D=100%20Main%20Street&subscription%5Buser%5D%5Bbilling_county%5D=Countyshire&subscription%5Buser%5D%5Bbilling_postcode%5D=N1%201AB&subscription%5Buser%5D%5Bbilling_town%5D=Townville&subscription%5Buser%5D%5Bemail%5D=john.smith%40example.com&subscription%5Buser%5D%5Bfirst_name%5D=John&subscription%5Buser%5D%5Blast_name%5D=Smith&subscription%5Buser%5D%5Bname%5D=John%20Smith&timestamp=2012-03-21T08%3A55%3A56Z";
             Assert.AreEqual(expected, url);
         }
     }

--- a/GoCardlessSdk.Tests/Helpers/UtilsTests.cs
+++ b/GoCardlessSdk.Tests/Helpers/UtilsTests.cs
@@ -98,7 +98,7 @@ namespace GoCardlessSdk.Tests.Helpers
                                                   }
                                    };
             Assert.AreEqual(
-                "amount=2.00&interval_length=1&interval_unit=month&merchant_id=merchant123&start_at=2011-01-01T12%3A00%3A00Z&user%5Bfirst_name%5D=John&user%5Bname%5D=John%20Smith",
+                "amount=2.00&interval_length=1&interval_unit=month&merchant_id=merchant123&setup_fee=0.00&start_at=2011-01-01T12%3A00%3A00Z&user%5Bfirst_name%5D=John&user%5Bname%5D=John%20Smith",
                 subscription.ToQueryString());
         }
 

--- a/GoCardlessSdk.Tests/Helpers/UtilsTests.cs
+++ b/GoCardlessSdk.Tests/Helpers/UtilsTests.cs
@@ -98,7 +98,7 @@ namespace GoCardlessSdk.Tests.Helpers
                                                   }
                                    };
             Assert.AreEqual(
-                "amount=2.00&interval_length=1&interval_unit=month&merchant_id=merchant123&setup_fee=0.00&start_at=2011-01-01T12%3A00%3A00Z&user%5Bfirst_name%5D=John&user%5Bname%5D=John%20Smith",
+                "amount=2.00&interval_length=1&interval_unit=month&merchant_id=merchant123&start_at=2011-01-01T12%3A00%3A00Z&user%5Bfirst_name%5D=John&user%5Bname%5D=John%20Smith",
                 subscription.ToQueryString());
         }
 

--- a/GoCardlessSdk.Tests/WebHooks/WebHooksTests.cs
+++ b/GoCardlessSdk.Tests/WebHooks/WebHooksTests.cs
@@ -10,7 +10,7 @@ namespace GoCardlessSdk.Tests.WebHooks
         [Test]
         public void Bill_InvalidSignature_ThrowsException()
         {
-            var request = File.ReadAllText("./Webhooks/Data/Bill invalid signature.txt");
+            var request = File.ReadAllText("./WebHooks/Data/Bill invalid signature.txt");
             GoCardless.AccountDetails.AppSecret = "test_secret";
             Assert.Throws<SignatureException>(() => WebHooksClient.ParseRequest(request));
         }
@@ -18,7 +18,7 @@ namespace GoCardlessSdk.Tests.WebHooks
         [Test]
         public void Bill_PayloadDeserializesOk()
         {
-            var request = File.ReadAllText("./Webhooks/Data/Bill.txt");
+            var request = File.ReadAllText("./WebHooks/Data/Bill.txt");
             GoCardless.AccountDetails.AppSecret = "test_secret";
 
             var payload = WebHooksClient.ParseRequest(request);
@@ -48,7 +48,7 @@ namespace GoCardlessSdk.Tests.WebHooks
         [Test]
         public void PreAuthorization_PayloadDeserializesOk()
         {
-            var request = File.ReadAllText("./Webhooks/Data/PreAuthorization.txt");
+            var request = File.ReadAllText("./WebHooks/Data/PreAuthorization.txt");
             GoCardless.AccountDetails.AppSecret = "test_secret";
             
             var payload = WebHooksClient.ParseRequest(request);
@@ -72,7 +72,7 @@ namespace GoCardlessSdk.Tests.WebHooks
         [Test]
         public void Subscription_PayloadDeserializesOk()
         {
-            var request = File.ReadAllText("./Webhooks/Data/Subscription.txt");
+            var request = File.ReadAllText("./WebHooks/Data/Subscription.txt");
             GoCardless.AccountDetails.AppSecret = "test_secret";
 
             var payload = WebHooksClient.ParseRequest(request);

--- a/GoCardlessSdk/Connect/SubscriptionRequest.cs
+++ b/GoCardlessSdk/Connect/SubscriptionRequest.cs
@@ -22,7 +22,7 @@ namespace GoCardlessSdk.Connect
         public string Name { get; set; }
         public string Description { get; set; }
         public int? IntervalCount { get; set; }
-        public decimal SetupFee { get; set; }
+        public decimal? SetupFee { get; set; }
 
         public UserRequest User { get; set; }
     }

--- a/GoCardlessSdk/Connect/SubscriptionRequest.cs
+++ b/GoCardlessSdk/Connect/SubscriptionRequest.cs
@@ -22,6 +22,7 @@ namespace GoCardlessSdk.Connect
         public string Name { get; set; }
         public string Description { get; set; }
         public int? IntervalCount { get; set; }
+        public decimal SetupFee { get; set; }
 
         public UserRequest User { get; set; }
     }


### PR DESCRIPTION
We've added a new setup_fee feature for subscriptions to the API - this allows a one-off bill to be added to the beginning of a subscription as if it were a "setup fee" at the beginning. This branch aims to add this to the library, though I haven't been able test it since I'm on a Mac?

If it works, the tests should pass still and the URL generated should include a subscription[setup_fee] parameter. On visiting the payment pages, it should mention the one-off charge alongside the subscription.

Can you test this and then merge if applicable for me?
