### PR TITLE
Adds chargeCustomerAt attribute to PostBill

### DIFF
--- a/GoCardlessSdk/Api/ApiClient.cs
+++ b/GoCardlessSdk/Api/ApiClient.cs
@@ -159,13 +159,13 @@ namespace GoCardlessSdk.Api
             return response.Data;
         }
 
-        public BillResponse PostBill(decimal amount, string preAuthorizationId, string name = null, string description = null)
+        public BillResponse PostBill(decimal amount, string preAuthorizationId, string name = null, string description = null, DateTimeOffset? chargeCustomerAt)
         {
           
             var restRequest = GetRestRequest("bills", Method.POST);
             restRequest.AddBody(new {bill = new
             {
-                amount = amount.ToString(CultureInfo.InvariantCulture), pre_authorization_id = preAuthorizationId, name, description
+                amount = amount.ToString(CultureInfo.InvariantCulture), pre_authorization_id = preAuthorizationId, charge_customer_at = chargeCustomerAt, name, description
             }});
             return Execute<BillResponse>(restRequest, HttpStatusCode.Created);
         }


### PR DESCRIPTION
Adds a `chargeCustomerAt` attribute to PostBill.

Before this can be merged in, we need to:
- Write specs
- Add a field to BillResponse
