### PR TITLE
Fixed processing 'null' values on MerchantResponse

### DIFF
--- a/GoCardlessSdk/Api/MerchantResponse.cs
+++ b/GoCardlessSdk/Api/MerchantResponse.cs
@@ -19,8 +19,8 @@ namespace GoCardlessSdk.Api
         public string Uri { get; set; }
         public decimal Balance { get; set; }
         public decimal PendingBalance { get; set; }
-        public DateTimeOffset NextPayoutDate { get; set; }
-        public decimal NextPayoutAmount { get; set; }
+        public DateTimeOffset? NextPayoutDate { get; set; }
+        public decimal? NextPayoutAmount { get; set; }
         public bool HideVariableAmount { get; set; }
         public SubResourceUrisResponse SubResourceUris { get; set; }
 


### PR DESCRIPTION
'NextPayoutDate' and 'NextPayoutAmount' were coming as 'null' in the API response so it couldn't be mapped to non-nullable type, so whole MerchantResponse couldn't be processed and was equal to 'null'.
